### PR TITLE
Add razzle-plugin-modify-eslint-loader-config

### DIFF
--- a/packages/razzle-plugin-modify-eslint-loader-config/README.md
+++ b/packages/razzle-plugin-modify-eslint-loader-config/README.md
@@ -1,0 +1,60 @@
+[![NPM version][npm-image]][npm-url]
+[![Build Status][travis-image]][travis-url]
+
+# razzle-plugin-modify-eslint-loader-config
+
+This package contains a plugin which can be used to modify eslint loader config
+## Usage in Razzle Projects
+
+```
+yarn add razzle-plugin-modify-eslint-loader-config
+```
+
+Using the plugin with the default options
+
+```js
+// razzle.config.js
+
+module.exports = {
+  plugins: [
+    'eslint',
+    'modify-eslint-loader-config' // This plugin should always be after eslint plugin
+  ],
+};
+```
+
+### With custom options:
+
+```js
+// razzle.config.js
+
+module.exports = {
+  plugins: [
+    'eslint',
+    {
+      // This plugin should always be after eslint plugin
+      name: 'modify-eslint-loader-config',
+      options: {
+        fix: true,  // enable autofix
+      },
+    },
+  ],
+};
+```
+
+## Options
+
+NB: By default this plugin sets `emitWarning` to true to force eslint errors to be shown as warnings (so compilation still succeeds).
+
+see https://github.com/webpack-contrib/eslint-loader#options
+
+## License
+
+MIT © [Thorgate](http://github.com/thorgate)
+
+
+[npm-url]: https://npmjs.org/package/razzle-plugin-modify-eslint-loader-config
+[npm-image]: https://img.shields.io/npm/v/razzle-plugin-modify-eslint-loader-config.svg?style=flat-square
+
+[travis-url]: https://travis-ci.com/thorgate/tg-spa-utils
+[travis-image]: https://travis-ci.com/thorgate/tg-spa-utils.svg?branch=master

--- a/packages/razzle-plugin-modify-eslint-loader-config/package.json
+++ b/packages/razzle-plugin-modify-eslint-loader-config/package.json
@@ -28,7 +28,8 @@
     "src"
   ],
   "peerDependencies": {
-    "razzle": ">=3.3.0 <4"
+    "razzle": ">=3.3.0 <4",
+    "razzle-plugin-eslint": ">=3.3.0 <4"
   },
   "scripts": {
     "clean": "echo Nothing to clean",

--- a/packages/razzle-plugin-modify-eslint-loader-config/package.json
+++ b/packages/razzle-plugin-modify-eslint-loader-config/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "razzle-plugin-modify-eslint-loader-config",
+  "version": "1.0.0-alpha.40",
+  "private": false,
+  "publishConfig": {
+    "access": "public"
+  },
+  "description": "Razzle plugin to modifty eslint loader config",
+  "main": "src/index.js",
+  "license": "MIT",
+  "author": "Thorgate <hi@thorgate.eu>",
+  "contributors": [
+    "Jörgen Ader <jorgen.ader@gmail.com> (https://github.com/metsavaht)",
+    "Jürno Ader <jyrno42@gmail.com> (https://github.com/jyrno42)"
+  ],
+  "homepage": "https://github.com/thorgate/tg-spa-utils/tree/master/packages/razzle-plugin-modify-eslint-loader-config#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/thorgate/tg-spa-utils.git"
+  },
+  "bugs": "https://github.com/thorgate/tg-spa-utils/issues",
+  "keywords": [
+    "razzle",
+    "plugin",
+    "eslint-loader"
+  ],
+  "files": [
+    "src"
+  ],
+  "peerDependencies": {
+    "razzle": ">=3.3.0 <4"
+  },
+  "scripts": {
+    "clean": "echo Nothing to clean",
+    "build": "echo Nothing to build",
+    "lint": "eslint src -c ../../.eslintrc.js --ext js"
+  }
+}

--- a/packages/razzle-plugin-modify-eslint-loader-config/src/index.js
+++ b/packages/razzle-plugin-modify-eslint-loader-config/src/index.js
@@ -1,0 +1,22 @@
+'use strict';
+
+import makeLoaderFinder from 'razzle-dev-utils/makeLoaderFinder';
+
+const eslintLoaderFinder = makeLoaderFinder('eslint-loader');
+
+module.exports = {
+    modifyWebpackConfig({ webpackConfig, options: { pluginOptions } }) {
+        const eslintLoaderIndex = webpackConfig.module.rules.findIndex(
+            eslintLoaderFinder
+        );
+
+        if (eslintLoaderIndex !== -1) {
+            webpackConfig.module.rules[eslintLoaderIndex].options = {
+                ...webpackConfig.module.rules[eslintLoaderIndex].options,
+                ...pluginOptions,
+            };
+        }
+
+        return webpackConfig;
+    },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4777,7 +4777,7 @@ debug@3.1.0, debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
+debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -4835,11 +4835,6 @@ deep-equal@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
   integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -4964,11 +4959,6 @@ detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -6762,7 +6752,7 @@ humanize-number@0.0.2:
   resolved "https://registry.yarnpkg.com/humanize-number/-/humanize-number-0.0.2.tgz#11c0af6a471643633588588048f1799541489c18"
   integrity sha1-EcCvakcWQ2M1iFiASPF5lUFInBg=
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -6937,7 +6927,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.2, ini@^1.3.4, ini@~1.3.0:
+ini@^1.3.2, ini@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -9405,15 +9395,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.3.2.tgz#3342dea100b7160960a450dc8c22160ac712a528"
-  integrity sha512-DUzITvPVDUy6vczKKYTnWc/pBZ0EnjMJnQ3y+Jo5zfKFimJs7S3HFCxCRZYB9FUZcrzUQr3WsmvZgddMEIZv6w==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -9531,22 +9512,6 @@ node-notifier@^6.0.0:
     shellwords "^0.1.1"
     which "^1.3.1"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.0.0-alpha.11, node-releases@^1.1.47:
   version "1.1.48"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.48.tgz#7f647f0c453a0495bcd64cbd4778c26035c2f03a"
@@ -9635,7 +9600,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.6, npm-packlist@^1.4.4:
+npm-packlist@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -9667,7 +9632,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -11347,16 +11312,6 @@ razzle@^3.0.0:
     webpack-node-externals "^1.7.2"
     webpackbar "^3.1.5"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 react-dev-utils@^6.0.4, react-dev-utils@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-6.1.1.tgz#a07e3e8923c4609d9f27e5af5207e3ca20724895"
@@ -12864,11 +12819,6 @@ strip-json-comments@^3.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
   integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
 strong-log-transformer@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz#0f5ed78d325e0421ac6f90f7f10e691d6ae3ae10"
@@ -12980,7 +12930,7 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
This plugin allows one to modify the eslint loader options configured by razzle eslint plugin. By default this enables the emitWarning option causing errors to be logged into the console without making the build fail.